### PR TITLE
Enable usage telemetry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This documentation provides an overview of the MCP Agent TypeScript framework, w
 - [Core Components](#core-components)
 - [Workflow Patterns](#workflow-patterns)
 - [Advanced Features](#advanced-features)
+- [Usage Telemetry](#usage-telemetry)
 - [Examples](#examples)
 
 ## Overview
@@ -217,6 +218,20 @@ const orchestrator = new Orchestrator({
   planner,
 });
 ```
+
+## Usage Telemetry
+
+MCP Agent anonymously collects usage metrics to help improve the product. The
+`usage_telemetry` section of your configuration controls this behaviour and is
+enabled by default:
+
+```yaml
+usage_telemetry:
+  enabled: true
+  enable_detailed_telemetry: false
+```
+
+Set `enabled` to `false` to disable all telemetry reporting.
 
 ## Examples
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -17,6 +17,7 @@ import { DecoratorRegistry } from '../executor/decorator_registry.js';
 import { ActivityRegistry } from '../executor/task_registry.js';
 import { HumanInputCallback, SignalWaitCallback } from '../types.js';
 import { ModelSelector } from '../workflows/llm/model_selector.js';
+import { sendUsageData } from '../telemetry/usage_tracking.js';
 
 // Import temporal executor conditionally
 let TemporalExecutor: any;
@@ -123,7 +124,11 @@ async function configureLogger(config: Settings): Promise<void> {
  * Configure usage telemetry
  */
 async function configureUsageTelemetry(_config: Settings): Promise<void> {
-  // TODO: Implement usage tracking
+  try {
+    await sendUsageData();
+  } catch (error) {
+    // Telemetry should never block initialization
+  }
 }
 
 /**

--- a/src/telemetry/usage_tracking.ts
+++ b/src/telemetry/usage_tracking.ts
@@ -1,6 +1,10 @@
 /**
  * Usage tracking for MCP Agent
  */
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 import { getSettings } from '../config.js';
 import { getLogger } from '../logging/logger.js';
 
@@ -17,16 +21,32 @@ export async function sendUsageData(): Promise<void> {
     return;
   }
 
-  // TODO: Implement usage tracking
-  // const data = { installation_id: uuidv4(), version: '0.1.0' };
-  // try {
-  //   await fetch('https://telemetry.example.com/usage', {
-  //     method: 'POST',
-  //     headers: { 'Content-Type': 'application/json' },
-  //     body: JSON.stringify(data),
-  //     signal: AbortSignal.timeout(2000), // 2 second timeout
-  //   });
-  // } catch (error) {
-  //   // Silently handle errors - telemetry should never interrupt the app
-  // }
+  try {
+    // Generate a hashed installation id
+    const installationId = createHash('sha256')
+      .update(uuidv4())
+      .digest('hex');
+
+    // Read package version
+    const pkgPath = path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      '../../package.json'
+    );
+    const { version } = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+    const data = {
+      installation_id: installationId,
+      version,
+    };
+
+    await fetch('https://telemetry.example.com/usage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+      signal: AbortSignal.timeout(2000), // 2 second timeout
+    });
+  } catch (error) {
+    // Silently handle errors - telemetry should never interrupt the app
+    logger.debug(`Failed to send usage data: ${error}`);
+  }
 }


### PR DESCRIPTION
## Summary
- implement usage telemetry data POST
- hook usage telemetry into context initialization
- document `usage_telemetry` config in docs

## Testing
- `npm test` *(fails: Cannot find module 'jest-cli')*

------
https://chatgpt.com/codex/tasks/task_e_6855d3b132b08325b23309ed74bc0312