### PR TITLE
Add more TypeScript examples

### DIFF
--- a/examples/functions/main.ts
+++ b/examples/functions/main.ts
@@ -1,0 +1,41 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+function addNumbers(a: number, b: number): number {
+  console.log(`Math expert is adding ${a} and ${b}`);
+  return a + b;
+}
+
+function multiplyNumbers(a: number, b: number): number {
+  console.log(`Math expert is multiplying ${a} and ${b}`);
+  return a * b;
+}
+
+async function exampleUsage() {
+  const app = new MCPApp({ name: 'mcp_agent_using_functions' });
+  await app.run(async (appInstance) => {
+    const logger = appInstance.logger;
+    const context = appInstance.context;
+    logger.info('Current config:', { data: context.config });
+
+    const mathAgent = new Agent({
+      name: 'math_agent',
+      instruction: `You are an expert in mathematics with access to some functions
+        to perform correct calculations. Your job is to identify the closest match
+        to a user's request, make the appropriate function calls, and return the result.`,
+      functions: [addNumbers, multiplyNumbers],
+      context: appInstance.context,
+    });
+
+    await mathAgent.initialize();
+    const llm = await mathAgent.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent }));
+    const result = await llm.generateStr('Add 2 and 3, then multiply the result by 4.');
+    logger.info(`Expert math result: ${result}`);
+    await mathAgent.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_agent/main.ts
+++ b/examples/mcp_basic_agent/main.ts
@@ -1,0 +1,42 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM, AnthropicAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (appInstance) => {
+    const logger = appInstance.logger;
+    const context = appInstance.context;
+    logger.info('Current config:', { data: context.config });
+
+    const fsServer = (context.config as any).mcp.servers?.filesystem;
+    if (fsServer && Array.isArray(fsServer.args)) {
+      fsServer.args.push(process.cwd());
+    }
+
+    const finder = new Agent({
+      name: 'finder',
+      instruction: `You are an agent with access to the filesystem, as well as the ability to fetch URLs. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the URI and CONTENTS of the closest match.`,
+      serverNames: ['fetch', 'filesystem'],
+      context: appInstance.context,
+    });
+
+    await finder.initialize();
+    const openAILlm = await finder.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent }));
+    const result1 = await openAILlm.generateStr('Print the contents of mcp_agent.config.yaml verbatim');
+    logger.info(`mcp_agent.config.yaml contents: ${result1}`);
+
+    const anthropicLlm = await finder.attachLLM(async (agent) => new AnthropicAugmentedLLM({ agent }));
+    const result2 = await anthropicLlm.generateStr('Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction');
+    logger.info(`First 2 paragraphs of Model Context Protocol docs: ${result2}`);
+
+    const result3 = await anthropicLlm.generateStr('Summarize those paragraphs in a 128 character tweet');
+    logger.info(`Paragraph as a tweet: ${result3}`);
+
+    await finder.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_azure_agent/README.md
+++ b/examples/mcp_basic_azure_agent/README.md
@@ -39,5 +39,5 @@ To run the "Finder" agent, navigate to the example directory and execute:
 ```bash
 cd examples/mcp_basic_azure_agent
 
-uv run --extra azure main.py
+npx tsx main.ts
 ```

--- a/examples/mcp_basic_azure_agent/main.ts
+++ b/examples/mcp_basic_azure_agent/main.ts
@@ -1,0 +1,30 @@
+import { MCPApp, Agent } from '../../src';
+import { AzureAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+    logger.info('Current config:', { data: context.config });
+
+    const finder = new Agent({
+      name: 'finder',
+      instruction: `You are an agent with the ability to fetch URLs. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the URI and CONTENTS of the closest match.`,
+      serverNames: ['fetch'],
+      context: instance.context,
+    });
+
+    await finder.initialize();
+    const llm = await finder.attachLLM(async (agent) => new AzureAugmentedLLM({ agent }));
+
+    const result1 = await llm.generateStr('Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction');
+    logger.info(`First 2 paragraphs of Model Context Protocol docs: ${result1}`);
+
+    await finder.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_bedrock_agent/README.md
+++ b/examples/mcp_basic_bedrock_agent/README.md
@@ -29,5 +29,5 @@ To run the "Finder" agent, navigate to the example directory and execute:
 ```bash
 cd examples/mcp_basic_bedrock_agent
 
-uv run main.py
+npx tsx main.ts
 ```

--- a/examples/mcp_basic_bedrock_agent/main.ts
+++ b/examples/mcp_basic_bedrock_agent/main.ts
@@ -1,0 +1,30 @@
+import { MCPApp, Agent } from '../../src';
+import { BedrockAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+    logger.info('Current config:', { data: context.config });
+
+    const finder = new Agent({
+      name: 'finder',
+      instruction: `You are an agent with the ability to fetch URLs. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the URI and CONTENTS of the closest match.`,
+      serverNames: ['fetch'],
+      context: instance.context,
+    });
+
+    await finder.initialize();
+    const llm = await finder.attachLLM(async (agent) => new BedrockAugmentedLLM({ agent }));
+
+    const result1 = await llm.generateStr('Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction');
+    logger.info(`First 2 paragraphs of Model Context Protocol docs: ${result1}`);
+
+    await finder.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_google_agent/README.md
+++ b/examples/mcp_basic_google_agent/README.md
@@ -36,5 +36,5 @@ To run the "Finder" agent, navigate to the example directory and execute:
 ```bash
 cd examples/mcp_basic_google_agent
 
-uv run main.py
+npx tsx main.ts
 ```

--- a/examples/mcp_basic_google_agent/main.ts
+++ b/examples/mcp_basic_google_agent/main.ts
@@ -1,0 +1,30 @@
+import { MCPApp, Agent } from '../../src';
+import { GoogleAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+    logger.info('Current config:', { data: context.config });
+
+    const finder = new Agent({
+      name: 'finder',
+      instruction: `You are an agent with the ability to fetch URLs. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the URI and CONTENTS of the closest match.`,
+      serverNames: ['fetch'],
+      context: instance.context,
+    });
+
+    await finder.initialize();
+    const llm = await finder.attachLLM(async (agent) => new GoogleAugmentedLLM({ agent }));
+
+    const result1 = await llm.generateStr('Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction');
+    logger.info(`First 2 paragraphs of Model Context Protocol docs: ${result1}`);
+
+    await finder.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_ollama_agent/README.md
+++ b/examples/mcp_basic_ollama_agent/README.md
@@ -13,6 +13,6 @@ ollama run llama3.1:8b
 ```
 
 Then simply run the example:
-`uv run main.py`
+`npx tsx main.ts`
 
 <img width="2160" alt="Image" src="https://github.com/user-attachments/assets/14cbfdf4-306f-486b-9ec1-6576acf0aeb7" />

--- a/examples/mcp_basic_ollama_agent/main.ts
+++ b/examples/mcp_basic_ollama_agent/main.ts
@@ -1,0 +1,43 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+    logger.info('Current config:', { data: context.config });
+
+    const fsServer = (context.config as any).mcp?.servers?.filesystem;
+    if (fsServer && Array.isArray(fsServer.args)) {
+      fsServer.args.push(process.cwd());
+    }
+
+    const finder = new Agent({
+      name: 'finder',
+      instruction: `You are an agent with access to the filesystem, as well as the ability to fetch URLs. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the URI and CONTENTS of the closest match.`,
+      serverNames: ['fetch', 'filesystem'],
+      context: instance.context,
+    });
+
+    await finder.initialize();
+
+    let llm = await finder.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent, model: 'llama3.2:3b' }));
+    const result1 = await llm.generateStr('Print the contents of mcp_agent.config.yaml verbatim');
+    logger.info(`Result: ${result1}`);
+
+    llm = await finder.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent, model: 'llama3.1:8b' }));
+    const result2 = await llm.generateStr('Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction');
+    logger.info(`Result: ${result2}`);
+
+    llm = await finder.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent, model: 'llama3.2:3b' }));
+    const result3 = await llm.generateStr('Summarize those paragraphs in a 128 character tweet');
+    logger.info(`Result: ${result3}`);
+
+    await finder.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_basic_slack_agent/README.md
+++ b/examples/mcp_basic_slack_agent/README.md
@@ -4,3 +4,9 @@ This example shows a "slack" Agent which has access to the 'slack' and 'filesyst
 
 You can use it to perform read/write actions on your Slack, as well as on your filesystem, including combination
 actions such as writing slack messages to disk or reading files and sending them over slack.
+
+Run with:
+
+```bash
+npx tsx main.ts
+```

--- a/examples/mcp_basic_slack_agent/main.ts
+++ b/examples/mcp_basic_slack_agent/main.ts
@@ -1,0 +1,40 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_basic_agent' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+
+    const slackAgent = new Agent({
+      name: 'slack_finder',
+      instruction: `You are an agent with access to the filesystem as well as Slack conversations. Your job is to identify the closest match to a user's request, make the appropriate tool calls, and return the results.`,
+      serverNames: ['filesystem', 'slack'],
+      context: instance.context,
+    });
+
+    const fsServer = (context.config as any).mcp?.servers?.filesystem;
+    if (fsServer && Array.isArray(fsServer.args)) {
+      fsServer.args.push(process.cwd());
+    }
+
+    await slackAgent.initialize();
+    logger.info('slack: Connected to server, calling list_tools...');
+    const tools = await slackAgent.listTools();
+    logger.info('Tools available:', { data: tools });
+
+    const llm = await slackAgent.attachLLM(async (agent) => new OpenAIAugmentedLLM({ agent }));
+    const result1 = await llm.generateStr('What was the last message in the general channel?');
+    logger.info(`Result: ${result1}`);
+
+    const result2 = await llm.generateStr('Summarize it for me so I can understand it better.');
+    logger.info(`Result: ${result2}`);
+
+    await slackAgent.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_github_to_slack_agent/README.md
+++ b/examples/mcp_github_to_slack_agent/README.md
@@ -65,5 +65,5 @@ uv sync --dev
 
 Run the application with:
 ```
-uv run main.py --owner <github-owner> --repo <repository-name> --channel <slack-channel>
+npx tsx main.ts --owner <github-owner> --repo <repository-name> --channel <slack-channel>
 ```

--- a/examples/mcp_hello_world/README.md
+++ b/examples/mcp_hello_world/README.md
@@ -1,1 +1,7 @@
 # Simplest usage of MCP Agent
+
+Run with:
+
+```bash
+npx tsx main.ts
+```

--- a/examples/mcp_hello_world/main.ts
+++ b/examples/mcp_hello_world/main.ts
@@ -1,0 +1,42 @@
+import { MCPApp, genClient, MCPConnectionManager } from '../../src';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_hello_world' });
+  await app.run(async (instance) => {
+    const { logger, context } = instance;
+
+    logger.info('Hello, world!');
+    logger.info('Current config:', { data: context.config });
+
+    const fetchClient = await genClient('fetch', context.serverRegistry);
+    logger.info('fetch: Connected to server, calling list_tools...');
+    const tools = await fetchClient.listTools();
+    logger.info('Tools available:', { data: tools });
+
+    const connectionManager = new MCPConnectionManager(context);
+    await connectionManager.initialize();
+
+    const filesystemClient = await connectionManager.getClient('filesystem');
+    logger.info('filesystem: Connected to server with persistent connection.');
+
+    const fetchClient2 = await connectionManager.getClient('fetch');
+    logger.info('fetch: Connected to server with persistent connection.');
+
+    if (filesystemClient) {
+      const fsTools = await filesystemClient.listTools();
+      logger.info('filesystem: Tools available:', { data: fsTools });
+    }
+
+    if (fetchClient2) {
+      const fetchTools = await fetchClient2.listTools();
+      logger.info('fetch: Tools available:', { data: fetchTools });
+    }
+
+    await connectionManager.close();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_model_selector/README.md
+++ b/examples/mcp_model_selector/README.md
@@ -13,5 +13,5 @@ https://github.com/user-attachments/assets/04257ae4-a628-4c25-ace2-6540620cbf8b
 Script mode:
 
 ```bash
-uv run main.py
+npx tsx main.ts
 ```

--- a/examples/mcp_playwright_agent/README.md
+++ b/examples/mcp_playwright_agent/README.md
@@ -38,5 +38,5 @@ The tool uses two MCP servers:
    - Filesystem paths
 
 ## Usage
-uv run main.py --criteria "Python developers in San Francisco" --max-results 7 --output "/desktop/JOB.csv"
-Run the script from the command line using: uv run main.py --criteria "THE POSITION YOU ARE LOOKING FOR" --max-results NUMBER OF MAX RESULTS --output "LOCATION OF SAVED RESULTS"
+npx tsx main.ts --criteria "Python developers in San Francisco" --max-results 7 --output "/desktop/JOB.csv"
+Run the script from the command line using: npx tsx main.ts --criteria "THE POSITION YOU ARE LOOKING FOR" --max-results NUMBER OF MAX RESULTS --output "LOCATION OF SAVED RESULTS"

--- a/examples/mcp_sse/README.md
+++ b/examples/mcp_sse/README.md
@@ -3,11 +3,11 @@
 This example shows how to use an SSE server with mcp-agent.
 
 - `server.py` is a simple server that runs on localhost:8000
-- `main.py` is the mcp-agent client that uses the SSE server.py
+- `main.ts` is the mcp-agent client that uses the SSE server.py
 
 To run, open two terminals:
 
 1. `uv run server.py`
-2. `uv run main.py`
+2. `npx tsx main.ts`
 
 <img width="1848" alt="image" src="https://github.com/user-attachments/assets/94c1e17c-a8d7-4455-8008-8f02bc404c28" />

--- a/examples/mcp_sse/main.ts
+++ b/examples/mcp_sse/main.ts
@@ -1,0 +1,24 @@
+import { MCPApp, Agent } from '../../src';
+
+async function testSSE(): Promise<void> {
+  const app = new MCPApp({ name: 'test-app' });
+  await app.run(async () => {
+    console.log('MCP App initialized.');
+
+    const agent = new Agent({
+      name: 'agent',
+      instruction: 'You are an assistant',
+      serverNames: ['mcp_test_server_sse'],
+    });
+
+    await agent.initialize();
+    const tools = await agent.listTools();
+    console.log(tools);
+    await agent.shutdown();
+  });
+}
+
+testSSE().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_sse_with_headers/README.md
+++ b/examples/mcp_sse_with_headers/README.md
@@ -1,7 +1,9 @@
 # MCP Agent example
 
-This example shows a basic agent that can connect to an MCP server over SSE with auth headers.
-You will need to update the mcp_agent.config.yaml file with the correct links to a hosted SSE
-server and your HTTP headers.
+This example shows a basic agent that can connect to an MCP server over SSE with auth headers. You will need to update the `mcp_agent.config.yaml` file with the correct links to a hosted SSE server and your HTTP headers.
 
-<img width="2160" alt="Image" src="https://github.com/user-attachments/assets/14cbfdf4-306f-486b-9ec1-6576acf0aeb7" />
+Run with:
+
+```bash
+npx tsx main.ts
+```

--- a/examples/mcp_sse_with_headers/main.ts
+++ b/examples/mcp_sse_with_headers/main.ts
@@ -1,0 +1,33 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_sse_with_auth' });
+  await app.run(async (instance) => {
+    const { logger } = instance;
+    logger.info('Current config:', { data: instance.context.config });
+
+    const agent = new Agent({
+      name: 'slack-agent',
+      instruction: 'You are an agent whose job is to interact with the Slack workspace for the user.',
+      serverNames: ['slack'],
+      context: instance.context,
+    });
+
+    await agent.initialize();
+    logger.info('slack-agent: Connected to server, calling list_tools...');
+    const result = await agent.listTools();
+    logger.info('Tools available:', { data: result });
+
+    const llm = await agent.attachLLM(async (a) => new OpenAIAugmentedLLM({ agent: a }));
+    const channels = await llm.generate('List all Slack channels in the workspace');
+    logger.info(`Slack channels: ${channels}`);
+
+    await agent.shutdown();
+  });
+}
+
+exampleUsage().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp_websockets/README.md
+++ b/examples/mcp_websockets/README.md
@@ -25,6 +25,6 @@ mcp:
       url: "wss://server.smithery.ai/@smithery-ai/github/ws?config=BASE64_ENCODED_CONFIG"
 ```
 
-Finally, run `uv run main.py <your github username>`. E.g. `uv run main.py saqadri`
+Finally, run `npx tsx main.ts <your github username>`. E.g. `npx tsx main.ts saqadri`
 
 <img width="979" alt="image" src="https://github.com/user-attachments/assets/55ca84fe-b9f3-4930-9f8f-3e7fb7449e5b" />

--- a/examples/mcp_websockets/main.ts
+++ b/examples/mcp_websockets/main.ts
@@ -1,0 +1,39 @@
+import { MCPApp, Agent } from '../../src';
+import { OpenAIAugmentedLLM } from '../../src/workflows/llm/index.js';
+
+async function exampleUsage(username: string): Promise<void> {
+  const app = new MCPApp({ name: 'mcp_websockets' });
+  await app.run(async (appInstance) => {
+    const logger = appInstance.logger;
+    const context = appInstance.context;
+    logger.info('Current config:', { data: context.config });
+
+    const agent = new Agent({
+      name: 'github-agent',
+      instruction: `You are an agent whose job is to interact with the Github repository for the user.`,
+      serverNames: ['smithery-github'],
+      context: appInstance.context,
+    });
+
+    await agent.initialize();
+    logger.info('github-agent: Connected to server, calling list_tools...');
+    const tools = await agent.listTools();
+    logger.info('Tools available:', { data: tools });
+
+    const llm = await agent.attachLLM(async (a) => new OpenAIAugmentedLLM({ agent: a }));
+    const result = await llm.generateStr(`List all public Github repositories created by the user ${username}.`);
+    console.log(`Github repositories: ${result}`);
+    await agent.shutdown();
+  });
+}
+
+const username = process.argv[2];
+if (!username) {
+  console.error('Usage: node main.ts <github-username>');
+  process.exit(1);
+}
+
+exampleUsage(username).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- expand TypeScript ports for example agents
- update some example READMEs with TypeScript run instructions

## Testing
- `npm test` *(fails: Cannot find module '/workspace/mcp-agent-ts/node_modules/jest-cli/build/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6855db8048b483258c9d1f165508eee0