### PR TITLE
Add secrets file merging to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ openai:
   default_model: gpt-4o
 ```
 
+The library automatically looks for a matching `mcp_agent.secrets.yaml` file in
+the same directory (or standard search paths) and merges any values it finds
+with your primary configuration.
+
 </details>
 
 <details>

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { getSettings } from '../src/config/index.js';
+
+describe('configuration with secrets', () => {
+  test('merges secrets with config file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-config-'));
+    const configPath = path.join(tmpDir, 'mcp_agent.yaml');
+    const secretsPath = path.join(tmpDir, 'mcp_agent.secrets.yaml');
+    fs.writeFileSync(configPath, 'openai:\n  default_model: gpt-4o\n');
+    fs.writeFileSync(secretsPath, 'openai:\n  api_key: sk-test\n');
+    process.env.MCP_AGENT_CONFIG_PATH = configPath;
+    const settings = getSettings();
+    expect(settings.openai?.default_model).toBe('gpt-4o');
+    expect(settings.openai?.api_key).toBe('sk-test');
+    delete process.env.MCP_AGENT_CONFIG_PATH;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- support provider sections and usage telemetry in SettingsSchema
- load `mcp_agent.secrets.yaml` automatically alongside config files
- add deep merge helper and merge secrets into settings
- document secrets behaviour in README
- test config/secrets merging

## Testing
- `npm test` *(fails: Cannot find module 'jest-cli/build/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6884dd0aba0883259edd26e2f4ac8390